### PR TITLE
molecule: postgresql_version required

### DIFF
--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -10,6 +10,7 @@
         - user: alice
           password: alice123
           databases: [alice]
+      postgresql_version: "10"
 
     - role: ansible-role-prometheus-postgres
       prometheus_postgres_dbname: alice


### PR DESCRIPTION
This is required by the current `ome.postgresql` role