### PR TITLE
Update exporter to 0.8.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,9 +1,9 @@
 ---
 # defaults file for prometheus-postgres
 
-prometheus_postgres_version: 0.4.6
+prometheus_postgres_version: 0.8.0
 prometheus_postgres_sha256: >-
-  9ed457c9a6d3a1e0132b3fe10f1d072457a667b009993a73e90b47ca99cc5bca
+  272ed14d3c360579d6e231db34a568ec08f61d2e163cf111e713929ffb6db3f5
 
 prometheus_postgres_dbname: postgres
 prometheus_postgres_data_source_name: "user=postgres dbname=\

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -10,7 +10,7 @@
         - user: alice
           password: alice123
           databases: [alice]
-      postgresql_version: "10"
+      postgresql_version: "11"
 
     - role: ansible-role-prometheus-postgres
       prometheus_postgres_dbname: alice

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -13,4 +13,6 @@ def test_services_running_and_enabled(host):
 
 def test_node_exporter_metrics(host):
     out = host.check_output('curl http://localhost:19187/metrics')
-    assert 'pg_database_size{datname="alice"}' in out
+    assert (
+        'pg_database_size{datname="alice",server="/var/run/postgresql/:5432"}'
+    ) in out


### PR DESCRIPTION
I think this is backwards compatible-  it works with older versions of PostgresSQL, and examination of the metrics suggests there is an additional label but the metric names are backwards compatible.

It's been a while though, so tag as a major release,`0.4.0`?

See https://github.com/IDR/deployment/issues/244