### PR TITLE
Run process with user different than postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ All variables are optional:
 - `prometheus_postgres_query_directory`: the directory containing query files which will be loaded by the exporter, default is `files/`
 - `prometheus_postgres_query_filenames`: A list of additional query files from `prometheus_postgres_query_directory`, default `[queries-default.yml]`
 - `prometheus_postgres_version`: the `postgres_exporter` version to be installed, default `0.4.6`
-- `prometheus_postgres_sha256`: the SHA256 checksum of the `postgres_exporter` bundle of version `prometheus_postgres_version, default: `9ed457c9a6d3a1e0132b3fe10f1d072457a667b009993a73e90b47ca99cc5bca`
+- `prometheus_postgres_sha256`: the SHA256 checksum of the `postgres_exporter` bundle of version `prometheus_postgres_version`, default: `9ed457c9a6d3a1e0132b3fe10f1d072457a667b009993a73e90b47ca99cc5bca`
+- `prometheus_postgres_system_user`: The OS user used to run `postgres_exporter`, default: `postgres` (OS user is created only when differs from defaults).
 
 
 Example playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,3 +15,5 @@ prometheus_postgres_query_filenames:
   - queries-default.yml
 
 prometheus_postgres_query_directory: files/
+
+prometheus_postgres_system_user: postgres

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
     comment: "prometheus_postgres_system_user"
     system: yes
     shell: /bin/false
-    create_home: no
+    create_home: false
   when: "prometheus_postgres_system_user != 'postgres'"
 
 - name: prometheus postgres | create directories

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
   user:
     name: "{{prometheus_postgres_system_user}}"
     comment: "prometheus_postgres_system_user"
-    system: yes
+    system: true
     shell: /bin/false
     create_home: false
   when: "prometheus_postgres_system_user != 'postgres'"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # tasks file for prometheus-postgres
 
-- name: Ensure {{prometheus_postgres_system_user}} exists
+- name: Ensure {{prometheus_postgres_system_user}} user exists
   user:
     name: "{{prometheus_postgres_system_user}}"
     comment: "prometheus_postgres_system_user"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,9 @@
   user:
     name: "{{prometheus_postgres_system_user}}"
     comment: "prometheus_postgres_system_user"
+    system: yes
+    shell: /bin/false
+    create_home: no
 
 - name: prometheus postgres | create directories
   become: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
     system: yes
     shell: /bin/false
     create_home: no
-  when: "prometheus_postgres_system_user != standard_prometheus_postgres_system_user"
+  when: "prometheus_postgres_system_user != 'postgres'"
 
 - name: prometheus postgres | create directories
   become: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,11 @@
 ---
 # tasks file for prometheus-postgres
 
+- name: Ensure {{prometheus_postgres_system_user}} exists
+  user:
+    name: "{{prometheus_postgres_system_user}}"
+    comment: "prometheus_postgres_system_user"
+
 - name: prometheus postgres | create directories
   become: true
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
     system: yes
     shell: /bin/false
     create_home: no
-  when: "prometheus_postgres_system_user != strandard_prometheus_postgres_system_user"
+  when: "prometheus_postgres_system_user != standard_prometheus_postgres_system_user"
 
 - name: prometheus postgres | create directories
   become: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,13 +1,14 @@
 ---
 # tasks file for prometheus-postgres
 
-- name: Ensure {{prometheus_postgres_system_user}} user exists
+- name: Ensure {{prometheus_postgres_system_user}} users exists
   user:
     name: "{{prometheus_postgres_system_user}}"
     comment: "prometheus_postgres_system_user"
     system: yes
     shell: /bin/false
     create_home: no
+  when: "prometheus_postgres_system_user != strandard_prometheus_postgres_system_user"
 
 - name: prometheus postgres | create directories
   become: true

--- a/templates/systemd-system-prometheus-postgres-exporter-service.j2
+++ b/templates/systemd-system-prometheus-postgres-exporter-service.j2
@@ -2,7 +2,7 @@
 Description=Prometheus Postgres Exporter Server
 
 [Service]
-User=postgres
+User={{ prometheus_postgres_system_user }}
 Environment="DATA_SOURCE_NAME={{ prometheus_postgres_data_source_name }}"
 ExecStart=/opt/prometheus/postgres_exporter/postgres_exporter \
     --extend.query-path /etc/prometheus/postgres-queries.yml \

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,1 +1,0 @@
-standard_prometheus_postgres_system_user: postgres

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,1 +1,1 @@
-strandard_prometheus_postgres_system_user: postgres
+standard_prometheus_postgres_system_user: postgres

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,1 @@
+strandard_prometheus_postgres_system_user: postgres


### PR DESCRIPTION
Really nice work!

I've submitted this PR because I had to run postgres_exporter pointing to remote DB. I prefer to not use `postgres` as user account when there is no postgresql database running.

This PR is retro-compatible so when the role is already applied the `postgres` user is not modified.