### PR TITLE
Support version 0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Prometheus Postgres exporter.
 This currently uses the local `postgres` administrator account on the PostgreSQL server.
 In future this should be changed to use an unprivileged account.
 
-See https://github.com/wrouesnel/postgres_exporter
+See https://github.com/prometheus-community/postgres_exporter
 
 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,9 +1,9 @@
 ---
 # defaults file for prometheus-postgres
 
-prometheus_postgres_version: 0.8.0
+prometheus_postgres_version: 0.9.0
 prometheus_postgres_sha256: >-
-  272ed14d3c360579d6e231db34a568ec08f61d2e163cf111e713929ffb6db3f5
+  ff541bd3ee19c0ae003d71424a75edfcc8695e828dd20d5b4555ce433c89d60b
 
 prometheus_postgres_dbname: postgres
 prometheus_postgres_data_source_name: "user=postgres dbname=\

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,21 +23,21 @@
 - name: prometheus postgres | download
   become: true
   get_url:
-    url: "https://github.com/wrouesnel/postgres_exporter/releases/download/\
+    # note the v0.9.0 in tag but 0.9.0 in the filename
+    # https://github.com/prometheus-community/postgres_exporter/releases/download/v0.9.0/postgres_exporter-0.9.0.linux-amd64.tar.gz
+    url: "https://github.com/prometheus-community/postgres_exporter/releases/download/\
       v{{ prometheus_postgres_version }}/\
-      postgres_exporter_v{{ prometheus_postgres_version }}_linux-amd64.tar.gz"
-    # "https://github.com/wrouesnel/postgres_exporter/releases/download/\
-    # v{{ prometheus_postgres_version }}/postgres_exporter"
+      postgres_exporter-{{ prometheus_postgres_version }}.linux-amd64.tar.gz"
     checksum: sha256:{{ prometheus_postgres_sha256 }}
     dest: "/opt/prometheus/postgres_exporter\
-      _v{{ prometheus_postgres_version }}_linux-amd64.tar.gz"
+      -{{ prometheus_postgres_version }}.linux-amd64.tar.gz"
     # dest: /opt/prometheus/postgres/postgres_exporter-0.2.2
 
 - name: prometheus postgres | install postgres-exporter
   become: true
   unarchive:
     src: "/opt/prometheus/postgres_exporter\
-      _v{{ prometheus_postgres_version }}_linux-amd64.tar.gz"
+      -{{ prometheus_postgres_version }}.linux-amd64.tar.gz"
     dest: /opt/prometheus
     group: root
     owner: root
@@ -47,7 +47,7 @@
   become: true
   file:
     src: "/opt/prometheus/postgres_exporter\
-      _v{{ prometheus_postgres_version }}_linux-amd64"
+      -{{ prometheus_postgres_version }}.linux-amd64"
     path: /opt/prometheus/postgres_exporter
     force: true
     state: link

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,8 +24,8 @@
   become: true
   get_url:
     # note the v0.9.0 in tag but 0.9.0 in the filename
-    url: "https://github.com/prometheus-community/postgres_exporter/releases/download/\
-      v{{ prometheus_postgres_version }}/\
+    url: "https://github.com/prometheus-community/postgres_exporter/\
+      releases/download/v{{ prometheus_postgres_version }}/\
       postgres_exporter-{{ prometheus_postgres_version }}.linux-amd64.tar.gz"
     checksum: sha256:{{ prometheus_postgres_sha256 }}
     dest: "/opt/prometheus/postgres_exporter\

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,14 +24,12 @@
   become: true
   get_url:
     # note the v0.9.0 in tag but 0.9.0 in the filename
-    # https://github.com/prometheus-community/postgres_exporter/releases/download/v0.9.0/postgres_exporter-0.9.0.linux-amd64.tar.gz
     url: "https://github.com/prometheus-community/postgres_exporter/releases/download/\
       v{{ prometheus_postgres_version }}/\
       postgres_exporter-{{ prometheus_postgres_version }}.linux-amd64.tar.gz"
     checksum: sha256:{{ prometheus_postgres_sha256 }}
     dest: "/opt/prometheus/postgres_exporter\
       -{{ prometheus_postgres_version }}.linux-amd64.tar.gz"
-    # dest: /opt/prometheus/postgres/postgres_exporter-0.2.2
 
 - name: prometheus postgres | install postgres-exporter
   become: true


### PR DESCRIPTION
Hello and thanks for an awesome role!

This is a patch to support v0.9.0. The filename does not have the "v" from v0.9.0..

Tested on Debian 10 with Postgres 11. Metrics are collected.

Those extra metrics are now all in the queries.yml in upstream https://github.com/prometheus-community/postgres_exporter/blob/master/queries.yaml so maybe we could also remove those extra files in this role? Thoughts?