### PR TITLE
Add support for ARM platforms

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,8 +2,6 @@
 # defaults file for prometheus-postgres
 
 prometheus_postgres_version: 0.9.0
-prometheus_postgres_sha256: >-
-  ff541bd3ee19c0ae003d71424a75edfcc8695e828dd20d5b4555ce433c89d60b
 
 prometheus_postgres_dbname: postgres
 prometheus_postgres_data_source_name: "user=postgres dbname=\

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,22 +20,40 @@
     - /opt/prometheus/postgres
     - /etc/prometheus
 
+- name: prometheus postgres | get checksums
+  set_fact:
+    checksum_list: "{{ lookup('url', \
+      'https://github.com/prometheus-community/postgres_exporter/\
+      releases/download/v' + prometheus_postgres_version + '/\
+      sha256sums.txt', wantlist=True) | list }}"
+  delegate_to: localhost
+  run_once: true
+
+- name: prometheus postgres | get checksum for {{ go_arch }}
+  set_fact:
+    exporter_checksum: "{{ item.split(' ')[0] }}"
+  with_items: "{{ checksum_list }}"
+  delegate_to: localhost
+  when:
+    - "('linux-' + go_arch + '.tar.gz') in item"
+
 - name: prometheus postgres | download
   become: true
   get_url:
     # note the v0.9.0 in tag but 0.9.0 in the filename
     url: "https://github.com/prometheus-community/postgres_exporter/\
       releases/download/v{{ prometheus_postgres_version }}/\
-      postgres_exporter-{{ prometheus_postgres_version }}.linux-amd64.tar.gz"
-    checksum: sha256:{{ prometheus_postgres_sha256 }}
+      postgres_exporter-{{ prometheus_postgres_version }}.\
+      linux-{{ go_arch }}.tar.gz"
+    checksum: sha256:{{ exporter_checksum }}
     dest: "/opt/prometheus/postgres_exporter\
-      -{{ prometheus_postgres_version }}.linux-amd64.tar.gz"
+      -{{ prometheus_postgres_version }}.linux-{{ go_arch }}.tar.gz"
 
 - name: prometheus postgres | install postgres-exporter
   become: true
   unarchive:
     src: "/opt/prometheus/postgres_exporter\
-      -{{ prometheus_postgres_version }}.linux-amd64.tar.gz"
+      -{{ prometheus_postgres_version }}.linux-{{ go_arch }}.tar.gz"
     dest: /opt/prometheus
     group: root
     owner: root
@@ -45,7 +63,7 @@
   become: true
   file:
     src: "/opt/prometheus/postgres_exporter\
-      -{{ prometheus_postgres_version }}.linux-amd64"
+      -{{ prometheus_postgres_version }}.linux-{{ go_arch }}"
     path: /opt/prometheus/postgres_exporter
     force: true
     state: link

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,10 @@
+---
+go_arch_map:
+  i386: '386'
+  x86_64: 'amd64'
+  aarch64: 'arm64'
+  armv7l: 'armv7'
+  armv6l: 'armv6'
+
+go_arch: >-
+  {{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}


### PR DESCRIPTION
Hello,
I noticed that the platform is hardcoded (amd64) and, while this was my reality for a long time, I'm using ARM now. Thus, the goal of this PR is to add support to ARM, similar to what we have on https://github.com/cloudalchemy/ansible-node-exporter.

I've run molecule on my machine and also run this role on my servers (arm64 and amd64) and it's working as expected.