### PR TITLE
Support the web config file with TLS server config

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ All variables are optional:
 - `prometheus_postgres_version`: the `postgres_exporter` version to be installed, default `0.4.6`
 - `prometheus_postgres_sha256`: the SHA256 checksum of the `postgres_exporter` bundle of version `prometheus_postgres_version`, default: `9ed457c9a6d3a1e0132b3fe10f1d072457a667b009993a73e90b47ca99cc5bca`
 - `prometheus_postgres_system_user`: The OS user used to run `postgres_exporter`, default: `postgres` (OS user is created only when differs from defaults).
+- `prometheus_postgres_tls_server_config`: The TLS server web config. [Documented here](https://github.com/prometheus/exporter-toolkit/tree/v0.1.0/https).
+    Example:
+    ```yaml
+    node_exporter_tls_server_config:
+      cert_file: /etc/node_exporter/tls.cert
+      key_file: /etc/node_exporter/tls.key
+    ```
 
 
 Example playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,3 +15,5 @@ prometheus_postgres_query_filenames:
 prometheus_postgres_query_directory: files/
 
 prometheus_postgres_system_user: postgres
+
+prometheus_postgres_web_config: '/etc/prometheus/web-config.yml'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -81,6 +81,15 @@
   notify:
     - restart prometheus-postgres
 
+- name: prometheus postgres | server web config
+  become: true
+  template:
+    dest: "{{ prometheus_postgres_web_config }}"
+    src: web-config.yml.j2
+    mode: 0644
+  notify:
+    - restart prometheus-postgres
+
 - name: prometheus postgres | server systemd service
   become: true
   template:

--- a/templates/systemd-system-prometheus-postgres-exporter-service.j2
+++ b/templates/systemd-system-prometheus-postgres-exporter-service.j2
@@ -6,6 +6,9 @@ User={{ prometheus_postgres_system_user }}
 Environment="DATA_SOURCE_NAME={{ prometheus_postgres_data_source_name }}"
 ExecStart=/opt/prometheus/postgres_exporter/postgres_exporter \
     --extend.query-path /etc/prometheus/postgres-queries.yml \
+    {% if prometheus_postgres_tls_server_config %}
+    --web.config.file={{ prometheus_postgres_web_config }} \
+    {% endif %}
     --web.listen-address :{{ prometheus_postgres_port }}
 
 [Install]

--- a/templates/web-config.yml.j2
+++ b/templates/web-config.yml.j2
@@ -1,0 +1,6 @@
+---
+{{ ansible_managed | comment }}
+{% if prometheus_postgres_tls_server_config | length > 0 %}
+tls_server_config:
+{{ prometheus_postgres_tls_server_config | to_nice_yaml | indent(2, true) }}
+{% endif %}


### PR DESCRIPTION
Added a variable `prometheus_postgres_tls_server_config` where the tls server configuration can be set according to the [exporter toolkit](https://github.com/prometheus/exporter-toolkit/tree/v0.1.0/https).