### PR TITLE
Change default listen address to 127.0.0.1 instead of 0.0.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Prometheus Postgres
-===================
+# Prometheus Postgres
 
 [![Actions Status](https://github.com/ome/ansible-role-prometheus-postgres/workflows/Molecule/badge.svg)](https://github.com/ome/ansible-role-prometheus-postgres/actions)
 [![Ansible Role](https://img.shields.io/badge/ansible--galaxy-prometheus_postgres-blue.svg)](https://galaxy.ansible.com/ui/standalone/roles/ome/prometheus_postgres/)
@@ -11,15 +10,13 @@ In future this should be changed to use an unprivileged account.
 
 See https://github.com/prometheus-community/postgres_exporter
 
-
-
-Role Variables
---------------
+## Role Variables
 
 All variables are optional:
 
 - `prometheus_postgres_dbname`: The database name
-- `prometheus_postgres_data_source_name`: implies `DATA_SOURCE_NAME` ENV variable in the [postgres_exporter](https://github.com/wrouesnel/postgres_exporter) 
+- `prometheus_postgres_data_source_name`: implies `DATA_SOURCE_NAME` ENV variable in the [postgres_exporter](https://github.com/wrouesnel/postgres_exporter)
+- `prometheus_postgres_addr`: Serve metrics on this address, default `127.0.0.1`
 - `prometheus_postgres_port`: Serve metrics on this port, default `9187`
 - `prometheus_postgres_query_directory`: the directory containing query files which will be loaded by the exporter, default is `files/`
 - `prometheus_postgres_query_filenames`: A list of additional query files from `prometheus_postgres_query_directory`, default `[queries-default.yml]`
@@ -27,17 +24,13 @@ All variables are optional:
 - `prometheus_postgres_sha256`: the SHA256 checksum of the `postgres_exporter` bundle of version `prometheus_postgres_version`, default: `9ed457c9a6d3a1e0132b3fe10f1d072457a667b009993a73e90b47ca99cc5bca`
 - `prometheus_postgres_system_user`: The OS user used to run `postgres_exporter`, default: `postgres` (OS user is created only when differs from defaults).
 
-
-Example playbook
-----------------
+## Example playbook
 
     - hosts: localhost
       roles:
       - role: ome.prometheus_postgres
         prometheus_postgres_dbname: test
 
-
-Author Information
-------------------
+## Author Information
 
 ome-devel@lists.openmicroscopy.org.uk

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ prometheus_postgres_dbname: postgres
 prometheus_postgres_data_source_name: "user=postgres dbname=\
   {{ prometheus_postgres_dbname }} host=/var/run/postgresql/ sslmode=disable"
 
+prometheus_postgres_addr: 127.0.0.1
 prometheus_postgres_port: 9187
 
 prometheus_postgres_query_filenames:

--- a/templates/systemd-system-prometheus-postgres-exporter-service.j2
+++ b/templates/systemd-system-prometheus-postgres-exporter-service.j2
@@ -6,7 +6,7 @@ User={{ prometheus_postgres_system_user }}
 Environment="DATA_SOURCE_NAME={{ prometheus_postgres_data_source_name }}"
 ExecStart=/opt/prometheus/postgres_exporter/postgres_exporter \
     --extend.query-path /etc/prometheus/postgres-queries.yml \
-    --web.listen-address :{{ prometheus_postgres_port }}
+    --web.listen-address {{ prometheus_postgres_addr }}:{{ prometheus_postgres_port }}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Currently, by default the exporter listens at 0.0.0.0 which is not recommended from a security standpoint. We should run the exporter in local ip ranges.